### PR TITLE
Access FlexSearch static methods via bundled export (static class methods of FlexSearch)

### DIFF
--- a/assets/js/flexsearch.js
+++ b/assets/js/flexsearch.js
@@ -12,15 +12,13 @@
  * A JavaScript file for flexsearch.
  */
 
-// import * as FlexSearch from 'flexsearch';
-import Index from 'flexsearch';
+import FlexSearch from 'flexsearch';
 
 (function () {
 
   'use strict';
 
-  // const index = new FlexSearch.Document({
-  const index = new Index.Document({
+  const index = FlexSearch.Document({
     tokenize: 'forward',
     document: {
       id: 'id',


### PR DESCRIPTION
## Summary

I looked at the most recent changes of you FlexSearch implementation to inspire myself and saw that you're not importing the module according to the docs.

Here are the relevant FlexSearch docs to look at: https://github.com/nextapps-de/flexsearch?tab=readme-ov-file#esmes6-bundled-module

```js
<script type="module">

    // FlexSearch is NOT available on window.FlexSearch
    // Access FlexSearch static methods via bundled export (static class methods of FlexSearch)

    import FlexSearch from "./node_modules/flexsearch/dist/flexsearch.bundle.module.min.js";

    const index = FlexSearch.Index(options);
    const document = FlexSearch.Document(options);
    const worker = FlexSearch.Worker(options);

</script>
```

I think it makes the code a bit more clearer. 

## Motivation

Adhere to FlexSearch docs

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test` (if relevant)
