### PR TITLE
Remove redundant check on the navbar

### DIFF
--- a/.changeset/unlucky-icons-juggle.md
+++ b/.changeset/unlucky-icons-juggle.md
@@ -1,0 +1,5 @@
+---
+"@thulite/doks-core": patch
+---
+
+Remove redundant check on the navbar

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -110,7 +110,7 @@
           {{ range .Site.Menus.main -}}
             {{- $active := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) -}}
             {{- $active = or $active (eq .Name $current.Title) -}}
-            {{- $active = or $active (and (eq .Name ($section | humanize)) (eq $current.Section $section)) -}}
+            {{- $active = or $active (eq .Name ($section | humanize)) -}}
             {{- $active = or $active (and (eq .Name "Blog") (eq $current.Section "blog" "authors")) -}}
             {{ if .HasChildren -}}
               <li class="nav-item dropdown">


### PR DESCRIPTION
## Redundant Check

Remove redundant check on the navbar. `(eq $current.Section $section)` is always true.

```
{{- $current := . -}}
{{- $section := $current.Section -}}
{{ range .Site.Menus.main -}}
  {{- $active := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) -}}
  {{- $active = or $active (eq .Name $current.Title) -}}
  {{- $active = or $active (and (eq .Name ($section | humanize)) (eq $current.Section $section)) -}}
```