### PR TITLE
Update terms.html

### DIFF
--- a/.changeset/popular-radios-rule.md
+++ b/.changeset/popular-radios-rule.md
@@ -1,0 +1,5 @@
+---
+"@thulite/doks-core": patch
+---
+
+ Fix showing taxonomy terms

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -9,7 +9,7 @@
         <div class="card card-terms my-3">
           <div class="card-body">
             <article>
-              <a class="stretched-link" href="{{ .RelPermalink }}">{{ .Params.title | title }} &rarr;</a>
+              <a class="stretched-link" href="{{ .RelPermalink }}">{{ .Title | title }} ({{ len .Pages }}) &rarr;</a>
             </article>
           </div>
         </div>


### PR DESCRIPTION
## Summary

For taxonomy terms, we should use .Page.Title or simply .Title instead of .Params.title. This will correctly display the name of each term (category, tag, etc.) in the list.

Also used the len function in Hugo to count the number of pages in each term.

## Basic example

You can see the updated behavior here: https://sr4001.net/tags/ or https://sr4001.net/categories/

Screenshot:
<img width="1096" alt="taxonomyterms" src="https://github.com/user-attachments/assets/0ec6fbc2-d69b-4fa1-a553-b976e1952eb6">

## Motivation

The current implementation does not show the taxonomy terms, only a right arrow (&rarr;) in the href for the term.  The 

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test` (if relevant)
