### PR TITLE
Using i18n for "in" and "by" for list and single blog post.

### DIFF
--- a/.changeset/itchy-ducks-tap.md
+++ b/.changeset/itchy-ducks-tap.md
@@ -1,0 +1,5 @@
+---
+"@thulite/doks-core": patch
+---
+
+Using i18n for "in" and "by" for list and single blog post.

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -22,14 +22,14 @@ other = "Example Guide"
 [home]
 other = "Home"
 
-[last_updated]
-other = "Last updated on"
-
 [in]
 other = "in"
 
 [by]
 other = "by"
+
+[last_updated]
+other = "Last updated on"
 
 [minute]
 one = "minute"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -25,6 +25,12 @@ other = "Home"
 [last_updated]
 other = "Last updated on"
 
+[in]
+other = "in"
+
+[by]
+other = "by"
+
 [minute]
 one = "minute"
 other = "minutes"

--- a/layouts/partials/main/blog-meta.html
+++ b/layouts/partials/main/blog-meta.html
@@ -3,14 +3,14 @@
   <small>
     {{- time.Format (default ":date_long" .Site.Params.dateFormat) .PublishDate -}}
     {{- with .Params.categories -}}
-      &nbsp;{{ i18n "in"}}&nbsp;
+      &nbsp;{{ i18n "in" }}&nbsp;
       {{- range $index, $category := . -}}
         {{ if gt $index 0 }}, {{ end -}}
         <a class="stretched-link position-relative link-muted" href="{{ "/categories/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>
       {{- end }}
     {{- end }}
     {{- with .Params.contributors -}}
-      &nbsp;{{ i18n "by"}}&nbsp;
+      &nbsp;{{ i18n "by" }}&nbsp;
       {{- range $index, $contributor := . -}}
         {{- if gt $index 0 }}{{ if eq $index $last }} and {{ else }}, {{ end }}{{ end -}}
         {{- with $.Site.GetPage "taxonomyTerm" (printf "contributors/%s" (urlize .)) -}}

--- a/layouts/partials/main/blog-meta.html
+++ b/layouts/partials/main/blog-meta.html
@@ -3,14 +3,14 @@
   <small>
     {{- time.Format (default ":date_long" .Site.Params.dateFormat) .PublishDate -}}
     {{- with .Params.categories -}}
-      &nbsp;in&nbsp;
+      &nbsp;{{ i18n "in"}}&nbsp;
       {{- range $index, $category := . -}}
         {{ if gt $index 0 }}, {{ end -}}
         <a class="stretched-link position-relative link-muted" href="{{ "/categories/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>
       {{- end }}
     {{- end }}
     {{- with .Params.contributors -}}
-      &nbsp;by&nbsp;
+      &nbsp;{{ i18n "by"}}&nbsp;
       {{- range $index, $contributor := . -}}
         {{- if gt $index 0 }}{{ if eq $index $last }} and {{ else }}, {{ end }}{{ end -}}
         {{- with $.Site.GetPage "taxonomyTerm" (printf "contributors/%s" (urlize .)) -}}


### PR DESCRIPTION
## Summary

Self explanatory (I dont know about another language, I'm sorry for that.)

## Basic example
- before
![before](https://github.com/user-attachments/assets/059acd76-7278-4a25-b0f1-234fa6d7b1a8)
- after
![after](https://github.com/user-attachments/assets/4520f3c6-5e17-4011-942c-1686ad272e9f)

## Motivation

For easier internationalization.

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test` (if relevant)
