### PR TITLE
layouts: use new `try` function

### DIFF
--- a/.changeset/wet-pigs-look.md
+++ b/.changeset/wet-pigs-look.md
@@ -1,0 +1,5 @@
+---
+"@thulite/doks-core": patch
+---
+
+layouts: use new try function (Hugo 0.141.0 and above)

--- a/layouts/_default/_markup/render-codeblock-kroki.html
+++ b/layouts/_default/_markup/render-codeblock-kroki.html
@@ -41,7 +41,7 @@ References:
 {{- $renderHookName := "kroki" }}
 
 {{- /* Verify minimum required version. */}}
-{{- $minHugoVersion := "0.114.0" }}
+{{- $minHugoVersion := "0.141.0" }}
 {{- if lt hugo.Version $minHugoVersion }}
   {{- errorf "The %q code block render hook requires Hugo v%s or later." $renderHookName $minHugoVersion }}
 {{- end }}

--- a/layouts/_default/_markup/render-codeblock-kroki.html
+++ b/layouts/_default/_markup/render-codeblock-kroki.html
@@ -86,14 +86,14 @@ References:
 {{- /* Get diagram. */}}
 {{- $body := dict "diagram_source" $inner "diagram_type" $diagramType "output_format" "SVG" | jsonify }}
 {{- $opts := dict "method" "post" "body" $body }}
-{{- with resources.GetRemote $apiEndpoint $opts }}
+{{- with try (resources.GetRemote $apiEndpoint $opts) }}
   {{- with .Err }}
     {{- errorf "The %q code block render hook was unable to get the remote diagram. See %s. %s" $renderHookName $position . }}
-  {{- else }}
+  {{- else with .Value }}
     {{- $attrs = merge $attrs (dict "src" .RelPermalink) }}
+  {{- else }}
+    {{- errorf "The %q code block render hook was unable to get the remote diagram. See %s" $renderHookName $position }}
   {{- end }}
-{{- else }}
-  {{- errorf "The %q code block render hook was unable to get the remote diagram. See %s" $renderHookName $position }}
 {{- end }}
 
 {{- /* Render. */}}

--- a/layouts/_default/_markup/render-codeblock-math.html
+++ b/layouts/_default/_markup/render-codeblock-math.html
@@ -102,14 +102,14 @@ References:
 
 {{- /* Get image. */}}
 {{- $url := printf "%s?%s" $apiEndpoint $qs }}
-{{- with resources.GetRemote $url }}
+{{- with try (resources.GetRemote $url) }}
   {{- with .Err }}
     {{- errorf "The %q code block render hook was unable to get the remote image. See %s. %s" $renderHookName $position . }}
-  {{- else }}
+  {{- else with .Value }}
     {{- $url = .RelPermalink }}
+  {{- else }}
+    {{- errorf "The %q code block render hook was unable to get the remote image. See %s" $renderHookName $position }}
   {{- end }}
-{{- else }}
-  {{- errorf "The %q code block render hook was unable to get the remote image. See %s" $renderHookName $position }}
 {{- end }}
 
 {{- /* Render. */}}

--- a/layouts/_default/_markup/render-codeblock-math.html
+++ b/layouts/_default/_markup/render-codeblock-math.html
@@ -42,7 +42,7 @@ References:
 {{- $renderHookName := "math" }}
 
 {{- /* Verify minimum required version. */}}
-{{- $minHugoVersion := "0.114.0" }}
+{{- $minHugoVersion := "0.141.0" }}
 {{- if lt hugo.Version $minHugoVersion }}
   {{- errorf "The %q code block render hook requires Hugo v%s or later." $renderHookName $minHugoVersion }}
 {{- end }}

--- a/layouts/shortcodes/math.html
+++ b/layouts/shortcodes/math.html
@@ -102,14 +102,14 @@ References:
 
 {{- /* Get image. */}}
 {{- $url := printf "%s?%s" $apiEndpoint $qs }}
-{{- with resources.GetRemote $url }}
+{{- with try (resources.GetRemote $url) }}
   {{- with .Err }}
     {{- errorf "The %q shortcode was unable to get the remote image. See %s. %s" $name $position . }}
-  {{- else }}
+  {{- else with .Value }}
     {{- $url = .RelPermalink }}
+  {{- else }}
+    {{- errorf "The %q shortcode was unable to get the remote image. See %s" $name $position }}
   {{- end }}
-{{- else }}
-  {{- errorf "The %q shortcode was unable to get the remote image. See %s" $name $position }}
 {{- end }}
 
 {{- /* Render. */}}

--- a/layouts/shortcodes/math.html
+++ b/layouts/shortcodes/math.html
@@ -48,7 +48,7 @@ References:
 */}}
 
 {{- /* Verify minimum required version. */}}
-{{- $minHugoVersion := "0.114.0" }}
+{{- $minHugoVersion := "0.141.0" }}
 {{- if lt hugo.Version $minHugoVersion }}
   {{- errorf "The %s shortcode requires Hugo v%s or later." .Name $minHugoVersion }}
 {{- end }}


### PR DESCRIPTION
## Summary

Hugo 0.141.0 introduced a new `try` function, replacing the way error
handling is done. Update the affected render hooks and shortcodes such
that they no longer break on Hugo 0.141.0 and above.

## Basic example

See gohugoio/hugo#13216 for migration instructions and further details.

## Motivation

1. New users of this theme are likely to use the latest version of
   Hugo--ensure the build does not break for those.

2. Our CI (and probably most of other automated Hugo builds) is set to
   always use the latest extended version of Hugo. Without this change,
   we'd have to pin it to 0.140.2 or below.

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test` (if relevant)

----

Some further remarks, which I wish to fully resolve before landing this
change. We can downgrade Hugo in our CI for the meantime.

Should we bump the minimum Hugo version in the affected files? I'm
seeing a minimum of 0.114.0 at the moment, checked individually.
Alternatively, should we just introduce a safeguard around the affected
block of code, checking if we are required to use `try` and do so
conditionally, based on the Hugo version in use?

Personally I'm leaning towards not touching that minimum version, and
instead wrap the affected blocks in a new safeguard. That way, we can
comfortably cut a patch-level release and not worry about a
(technically) breaking change. Please let me know what you think.
