### PR TITLE
fix: update search template to pass W3 validation

### DIFF
--- a/.changeset/serious-keys-know.md
+++ b/.changeset/serious-keys-know.md
@@ -1,0 +1,5 @@
+---
+"@thulite/doks-core": patch
+---
+
+fix: update search template to pass W3 validation

--- a/layouts/_partials/header/search-modal.html
+++ b/layouts/_partials/header/search-modal.html
@@ -2,7 +2,7 @@
   <div class="modal-dialog modal-dialog-scrollable modal-fullscreen-md-down">
     <div class="modal-content">
       <div class="modal-header">
-        <h1 class="modal-title fs-5 visually-hidden" id="searchModalLabel">{{ i18n "search_placeholder" }}</h1>
+        <h2 class="modal-title fs-5 visually-hidden" id="searchModalLabel">{{ i18n "search_placeholder" }}</h2>
         <button type="button" class="btn-close visually-hidden" data-bs-dismiss="modal" aria-label="Close"></button>
         <div class="search-input flex-grow-1 d-none">
           <form id="search-form" class="search-form" action="#" method="post" accept-charset="UTF-8" role="search">
@@ -25,7 +25,7 @@
               <div class="card-body">
                 <header>
                   <h2 class="h5 title title-submitted mb-0"><a class="stretched-link text-decoration-none text-reset" href="#">Title here</a></h2>
-                  <div class="submitted{{ if eq site.Params.doks.showDate false }} d-none{{ end }}"><time class="created-date">Date here</time></div>
+                  <div class="submitted{{ if eq site.Params.doks.showDate false }} d-none{{ end }}"><time class="created-date">{{ (time.AsTime 0).Format "2006-01-02T15:04:05-07:00" }}</time></div>
                 </header>
                 <div class="content{{ if eq site.Params.doks.showSummary false }} d-none{{ end }}">Summary here</div>
               </div>

--- a/layouts/_partials/header/search-modal.html
+++ b/layouts/_partials/header/search-modal.html
@@ -25,7 +25,7 @@
               <div class="card-body">
                 <header>
                   <h2 class="h5 title title-submitted mb-0"><a class="stretched-link text-decoration-none text-reset" href="#">Title here</a></h2>
-                  <div class="submitted{{ if eq site.Params.doks.showDate false }} d-none{{ end }}"><time class="created-date">{{ (time.AsTime 0).Format "2006-01-02T15:04:05-07:00" }}</time></div>
+                  <div class="submitted{{ if eq site.Params.doks.showDate false }} d-none{{ end }}"><time class="created-date" datetime="{{ (time.AsTime 0).Format "2006-01-02T15:04:05-07:00" }}">{{ (time.AsTime 0).Format "2006-01-02T15:04:05-07:00" }}</time></div>
                 </header>
                 <div class="content{{ if eq site.Params.doks.showSummary false }} d-none{{ end }}">Summary here</div>
               </div>


### PR DESCRIPTION
Without this W3 validator complains on the \<h1>and the non-time in the \<time> element.

So we use an appropriately styled h2, and Go time 0 (which is 1969-12-31T19:00:00-05:00). It is
replaced by the search JavaScript anyway. 

See #129 

## Basic example

No site creator or content editor changes

## Motivation

Fixes W3 validation errors.

Closes #129 

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [x] Supports all screen sizes (if relevant) (not relevant)
- [x] Supports both light and dark mode (if relevant) (not relevant)
- [x] Passes `npm run test` (if relevant) (not relevant)
