### PR TITLE
feat: add enhanced link render hook

### DIFF
--- a/.changeset/cold-donuts-divide.md
+++ b/.changeset/cold-donuts-divide.md
@@ -1,0 +1,5 @@
+---
+"@thulite/doks-core": patch
+---
+
+feat: add enhanced link render hook

--- a/layouts/_markup/render-link.html
+++ b/layouts/_markup/render-link.html
@@ -131,7 +131,7 @@ either of these shortcodes in conjunction with this render hook.
       {{- with urls.Parse .Destination }}
           {{- $u = .  }}
       {{- else }}
-          {{- errorf "The %q render hook was unable to parse the destination %q in %s as a URL" $renderHookName .Destination $contentPath }} }}
+          {{- errorf "The %q render hook was unable to parse the destination %q in %s as a URL" $renderHookName .Destination $contentPath }}
       {{- end }}
 
       {{- /* Set common message. */}}

--- a/layouts/_markup/render-link.html
+++ b/layouts/_markup/render-link.html
@@ -13,7 +13,7 @@
 - added @thulite/doks-core email obfuscation logic (2025-08-02)
 - added logic for branch bundles to get page resources from section page
   when called from a child page (2025-08-02)
-- added fallback to using link (.Destination) verbatime (2025-08-17)
+- added fallback to using link (.Destination) verbatim (2025-08-17)
 */ -}}
 
 {{- /* Last modified: 2023-03-26T10:05:59-07:00 (by Veriphor) */}}

--- a/layouts/_markup/render-link.html
+++ b/layouts/_markup/render-link.html
@@ -1,3 +1,119 @@
+{{- /* cspell:ignore Georg Makowski Veriphor warnf errorf */ -}}
+{{- /* Changes by Georg Makowski:
+- added a class to the resulting link (2023-03-27)
+- added an error message in case .Destination can’t be parsed (2023-03-28)
+- added an error message in case .Path can’t be parsed (2023-04-01)
+- added two special pseudo-link targets: "abbr" and "dfn". They generate the corresponding HTML inline tags with attributes (2023-04-12)
+- added a separate errorlevel for fragments (2023-04-17)
+- added a search by the relref function in the case a page name can’t be resolved by .GetPage (2023-04-18)
+- added a comparison for absolute links: In case the link points to the actual site its changed into a relative one. (2023-08-08)
+*/ -}}
+
+{{- /* Changes by Daniel F. Dickinson
+- added @thulite/doks-core email obfuscation logic (2025-08-02)
+- added logic for branch bundles to get page resources from section page
+  when called from a child page (2025-08-02)
+- added fallback to using link (.Destination) verbatime (2025-08-17)
+*/ -}}
+
+{{- /* Last modified: 2023-03-26T10:05:59-07:00 (by Veriphor) */}}
+
+{{- /*
+Copyright 2023 Veriphor LLC
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+*/}}
+
+{{- /*
+This render hook resolves internal destinations in the following order:
+
+  1. Content page
+  2. Page resource (e.g., a PDF file in a page bundle)
+  3. Global resource (e.g., a PDF file in the assets directory)
+
+External destinations are not modified.
+
+You must place global resources in the assets directory. If you have placed
+your resources in the static directory, and you are unable or unwilling to move
+them, you must mount the static directory to the assets directory by including
+both of these entries in your site configuration:
+
+  [[module.mounts]]
+  source = 'assets'
+  target = 'assets'
+
+  [[module.mounts]]
+  source = 'static'
+  target = 'assets'
+
+By default, if this render hook is unable to resolve a destination, including a
+fragment if present, it passes the destination through without modification. To
+emit a warning or error, set the error level in your site configuration:
+
+  [params.render_hooks.link]
+  errorLevel = 'error' # ignore (default), warning, or error
+
+In this configuration, when this render hook cannot resolve a destination, it
+throws an error and fails the build.
+
+This render hook may be unable to resolve destinations created with the ref and
+relref shortcodes. Unless you set the error level to ignore you should not use
+either of these shortcodes in conjunction with this render hook.
+
+@context {string} Destination The link destination.
+@context {page} Page A reference to the page containing the link.
+@context {string} PlainText The link description as plain text.
+@context {string} Text The link description.
+@context {string} Title The link title.
+
+@returns {template.html}
+*/}}
+
+{{- /* Initialize. */}}
+{{- $renderHookName := "link" }}
+{{- $page := $.Page -}}
+{{- $pBundle := $page.CurrentSection }}
+{{- $ctx := . }}
+
+{{- /* Verify minimum required version. */}}
+{{- $minHugoVersion := "0.111.3" }}
+{{- if lt hugo.Version $minHugoVersion }}
+    {{- errorf "The %q render hook requires Hugo v%s or later." $renderHookName $minHugoVersion }}
+{{- end }}
+
+{{- /* Error level when unable to resolve link destination: ignore, warning, or error. */}}
+{{- $errorLevel := or site.Params.render_hooks.link.errorLevel "warning" | lower }}
+
+{{- /* Validate error level. */}}
+{{- if not (in (slice "ignore" "warning" "error") $errorLevel) }}
+    {{- errorf "The %q render hook is misconfigured. The errorLevel %q is invalid. Please check your site configuration." $renderHookName $errorLevel }}
+{{- end }}
+
+{{- /* Error level when unable to resolve fragments: ignore, warning */}}
+{{- $errorLevelFragment := or site.Params.render_hooks.fragments.errorLevel "ignore" | lower }}
+{{- if not (in (slice "ignore" "warning" ) $errorLevelFragment) }}
+    {{- errorf "The %q render hook is misconfigured. The errorLevel %q is invalid. Please check your site configuration." $renderHookName $errorLevelFragment }}
+{{- end }}
+
+{{- /* Determine content path for warning and error messages. */}}
+
+{{- $contentPath := "" }}
+{{- with .Page.File }}
+        {{- $contentPath = .Path }}
+{{- else }}
+        {{- $contentPath = "" }}
+{{- end }}
+
 {{ if (strings.HasPrefix .Destination "mailto") -}}
   {{ with .Text -}}
     {{ partial "main/email" (dict "emailAddress" $.Destination "emailTitle" .) }}
@@ -5,5 +121,150 @@
     {{ partial "main/email" (dict "emailAddress" $.Destination) }}
   {{ end -}}
 {{ else -}}
-  <a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}</a>
+  {{- if eq .Destination "abbr" }}
+      {{- printf "<abbr title=%q>%s</abbr>" .Title .Text | safeHTML }}
+  {{- else if eq .Destination "dfn" }}
+      {{- printf "<dfn id=%q>%s</dfn>" (.Title | anchorize) .Text | safeHTML }}
+  {{- else }}
+      {{- /* Parse destination. */}}
+      {{- $u := "" }}
+      {{- with urls.Parse .Destination }}
+          {{- $u = .  }}
+      {{- else }}
+          {{- errorf "The %q render hook was unable to parse the destination %q in %s as a URL" $renderHookName .Destination $contentPath }} }}
+      {{- end }}
+
+      {{- /* Set common message. */}}
+      {{- $msg := printf "The %q render hook was unable to resolve the destination %q in %s" $renderHookName $u.String $contentPath }}
+
+      {{- /* Set attributes for anchor element. */}}
+      {{- $attrs := dict "href" $u.String }}
+      {{- if and $u.IsAbs (ne (print "https://" $u.Hostname) site.Home.Permalink) }}
+          {{- /* Destination is external. */}}
+          {{- $attrs = merge $attrs (dict "rel" "external") }}
+      {{- else }}
+          {{- with $u.Path }}
+              {{- with $p := or ($page.GetPage .) ($page.GetPage (strings.TrimRight "/" .)) }}
+                  {{- /* Destination is a path to a page. */}}
+                  {{- $href := .RelPermalink }}
+                  {{- with $u.RawQuery }}
+                      {{- $href = printf "%s?%s" $href . }}
+                  {{- end }}
+                  {{- with $u.Fragment }}
+                      {{- $ctx := dict
+                      "contentPath" $contentPath
+                      "errorLevel" $errorLevelFragment
+                      "page" $p
+                      "parsedURL" $u
+                      "renderHookName" $renderHookName
+                      }}
+                      {{- partial "inline/h-rh-l/validate-fragment.html" $ctx }}
+                      {{- $href = printf "%s#%s" $href . }}
+                  {{- end }}
+                  {{- $attrs = dict "href" $href }}
+              {{- else }}
+                  {{- with $pBundle.Resources.Get $u.Path }}
+                      {{- /* Destination is a page resource; drop query and fragment. */}}
+                      {{- $attrs = dict "href" .RelPermalink }}
+                  {{- else }}
+                      {{- with resources.Get $u.Path }}
+                          {{- /* Destination is a global resource; drop query and fragment. */}}
+                          {{- $attrs = dict "href" .RelPermalink }}
+                      {{- else }}
+                        {{- if site.Params.render_hooks.link.staticFallback | default $page.Params.render_hooks.link.staticFallback | default true }}
+                            {{- $attrs = dict "href" $ctx.Destination }}
+                        {{- else }}
+                          {{- if eq $errorLevel "warning" }}
+                              {{- warnf $msg }}
+                          {{- else if eq $errorLevel "error" }}
+                              {{- errorf $msg }}
+                          {{- end }}
+                        {{- end }}
+                      {{- end }}
+                  {{- end }}
+              {{- end }}
+          {{- else }}
+              {{- with $u.Fragment }}
+                  {{- /* Destination is on the same page; prepend relative permalink. */}}
+                  {{- $ctx := dict
+                  "contentPath" $contentPath
+                  "errorLevel" $errorLevelFragment
+                  "page" $page
+                  "parsedURL" $u
+                  "renderHookName" $renderHookName
+                  }}
+                  {{- partial "inline/h-rh-l/validate-fragment.html" $ctx }}
+                  {{- $attrs = dict "href" (printf "%s#%s" $page.RelPermalink .) }}
+              {{- else }}
+                  {{- if eq $errorLevel "warning" }}
+                      {{- warnf $msg }}
+                  {{- else if eq $errorLevel "error" }}
+                      {{- errorf $msg }}
+                  {{- end }}
+              {{- end }}
+          {{- end }}
+      {{- end }}
+      {{- with .Title }}
+          {{- $attrs = merge $attrs (dict "title" .) }}
+      {{- end -}}
+
+      {{- /* Render anchor element. */ -}}
+      <a class="link link--text"
+              {{- range $k, $v := $attrs }}
+                  {{- printf " %s=%q" $k $v | safeHTMLAttr }}
+              {{- end -}}
+      >{{ .Text | safeHTML }}</a>
+  {{- end -}}
+{{- end -}}
+
+{{- define "partials/inline/h-rh-l/validate-fragment.html" }}
+    {{- /*
+  Validates the fragment portion of a link destination.
+
+  @context {string} contentPath The page containing the link.
+  @context {string} errorLevel The error level when unable to resolve destination; ignore (default), warning, or error.
+  @context {page} page The page corresponding to the link destination
+  @context {struct} parsedURL The link destination parsed by urls.Parse.
+  @context {string} renderHookName The name of the render hook.
+  */}}
+
+    {{- /* Initialize. */}}
+    {{- $contentPath := .contentPath }}
+    {{- $errorLevel := .errorLevel }}
+    {{- $p := .page }}
+    {{- $u := .parsedURL }}
+    {{- $renderHookName := .renderHookName }}
+
+    {{- /* Validate. */}}
+    {{- with $u.Fragment }}
+        {{- if $p.Fragments.Identifiers.Contains . }}
+            {{- if gt ($p.Fragments.Identifiers.Count .) 1 }}
+                {{- $msg := printf "The %q render hook detected duplicate heading IDs %q in %s" $renderHookName . $contentPath }}
+                {{- if eq $errorLevel "warning" }}
+                    {{- warnf $msg }}
+                {{- else if eq $errorLevel "error" }}
+                    {{- errorf $msg }}
+                {{- end }}
+            {{- end }}
+        {{- else }}
+            {{- /* Determine target path for warning and error message. */}}
+            {{- $targetPath := "" }}
+            {{- with $p.File }}
+                {{- $targetPath = .Path }}
+            {{- else }}
+                {{- $targetPath = $contentPath }}
+            {{- end }}
+            {{- /* Set common message. */}}
+            {{- $msg := printf "The %q render hook was unable to find heading ID %q in %s. See %s" $renderHookName . $targetPath $contentPath }}
+            {{- if eq $targetPath $contentPath }}
+                {{- $msg = printf "The %q render hook was unable to find heading ID %q in %s" $renderHookName . $targetPath }}
+            {{- end }}
+            {{- /* Throw warning or error. */}}
+            {{- if eq $errorLevel "warning" }}
+                {{- warnf $msg }}
+            {{- else if eq $errorLevel "error" }}
+                {{- errorf $msg }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
 {{- end -}}


### PR DESCRIPTION
Applies to Markdown links. With

```toml
[render_hooks]
[render_hooks.link]
staticFallback = true
```
(the default) in `params.toml` (or not present), behaviour falls back to current behaviour of taking supplied link verbatim, after attempting to resolve as below. With `false` attempts to resolve as below and emits an error or warning if the link cannot be found.

Links are first resolved as content page, then page resources, then global, and if no such resource exists, the default falls back to using the link verbatim. This can be disabled.

Email links are handled as before; they are obfuscated.

Code originally by Veriphor and modified by various contributors

## Summary

Brief explanation of the proposed changes.

## Basic example

With blog and a docs section, given a page `/docs/lorem/ipsum.md`,
a link in `/blog/post-3.md` like `[doleur](../docs/lorem/ipsum.md)` will be resolved into a link like `<a href="/docs/lorem/ipsum/">doleur</a>` but (the advantage of this scheme) if
you mistyped as `[doleur](../docs/lorem/ipsem.md)` it would issue a warning or error (as you configured).

### `params.toml`

```toml
[render_hooks]
[render_hooks.link]
errorLevel = "warning" # warning (default) or error (fails build)
staticFallback = true # true (default) or false
[render_hooks.fragments]
errorLevel = "ignore" # ignore (default), warning, or error (fails build)
```

## Motivation

1. Detect broken internal links at build time
2. Easier access to global and page bundle resources
3. Easier to create correct internal links

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [x] Supports all screen sizes (if relevant) (not relevant)
- [x] Supports both light and dark mode (if relevant) (not relevant)
- [x] Passes `npm run test` (if relevant) (not relevant)
