### PR TITLE
fix: need to check page param before site param

### DIFF
--- a/layouts/_markup/render-link.html
+++ b/layouts/_markup/render-link.html
@@ -171,7 +171,7 @@ either of these shortcodes in conjunction with this render hook.
                           {{- /* Destination is a global resource; drop query and fragment. */}}
                           {{- $attrs = dict "href" .RelPermalink }}
                       {{- else }}
-                        {{- if site.Params.render_hooks.link.staticFallback | default $page.Params.render_hooks.link.staticFallback | default true }}
+                        {{- if $page.Params.render_hooks.link.staticFallback | default site.Params.render_hooks.link.staticFallback | default true }}
                             {{- $attrs = dict "href" $ctx.Destination }}
                         {{- else }}
                           {{- if eq $errorLevel "warning" }}


### PR DESCRIPTION
## Summary

If one checks the site.Params before page.Params, the presence of a value for site.Params overrides the page.Params, and we want the opposite behaviour (page overrides site).

## Basic example

`params.toml`

```toml
[render_hooks.link]
staticFallback = false # true (default) or false
```

content page yaml

```yaml
render_hooks:
  link:
    staticFallback: true
```

## Motivation

We want page params to override site params, before that was not the case.

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [x] Supports all screen sizes (if relevant) (not relevant)
- [x] Supports both light and dark mode (if relevant) (not relevant)
- [x] Passes `npm run test` (if relevant) (not relevant)
